### PR TITLE
Ignore hidden files.

### DIFF
--- a/src/clj/shadow/cljs/build.clj
+++ b/src/clj/shadow/cljs/build.clj
@@ -143,7 +143,8 @@
         root-len (inc (count root-path))]
     (for [file (file-seq root)
           :let [abs-path (.getAbsolutePath file)]
-          :when (is-cljs-resource? abs-path)
+          :when (and (is-cljs-resource? abs-path)
+                     (not (.isHidden file)))
           :let [rel-path (.substring abs-path root-len)]]
       {:name rel-path
        :file file


### PR DESCRIPTION
Shadow currently picks up hidden files, which includes things like Emacs autosave files, and can cause the compilation to crash.

Ignoring hidden files is a simple interop call, and Java makes it a cross-platform one to boot. :-)
