### PR TITLE
fix js path separator in Windows. Use / instead of \

### DIFF
--- a/src/clj/shadow/cljs/build.clj
+++ b/src/clj/shadow/cljs/build.clj
@@ -1,5 +1,6 @@
 (ns shadow.cljs.build
   (:import [java.io File PrintStream StringWriter StringReader]
+           [java.util.regex.Pattern]
            [java.net URL]
            [com.google.javascript.jscomp JSModule SourceFile CompilerOptions$DevMode CompilerOptions$TracerMode])
   (:require [clojure.pprint :refer (pprint)]
@@ -219,7 +220,10 @@
           :when (and (is-cljs-resource? abs-path)
                      (not (.isHidden file)))
           :let [rel-path (.substring abs-path root-len)]]
-      {:name rel-path
+      {:name (str/join "/"  (-> rel-path
+                                (clojure.string/split (-> (File/separator)
+                                                          (Pattern/quote)
+                                                          (re-pattern)))))
        :file file
        :source-path path
        :last-modified (.lastModified file)


### PR DESCRIPTION
Problem:
in previous commits, js files's path separator in windows is \

for example, if main.js file is located in a directory named company, shadow-build generates this log:

`Compile CLJS: "company\main.cljs"`

and writes this:

`goog.addDependency("company\main.js")`

browser interpretes the \ as an escape character and try to find file
companyain.js instead.

`"NetworkError: 404 Not Found - http://localhost:65432/companyain.js"`

Solution:

When creating a js file's path, separates the path elements by OS's specific
separator and then join those path elements with /.

So, in windows shadow-build generates :

`goog.addDependency("company/main.js")`
