### PR TITLE
Remove the guard on file rebuilding.

### DIFF
--- a/src/cljs/shadow/cljs/live_reload.cljs
+++ b/src/cljs/shadow/cljs/live_reload.cljs
@@ -20,12 +20,7 @@
   )
 
 (defn handle-changes [{:keys [public-path before-load after-load] :as config} {:keys [js] :as changes}]
-  (let [js-to-reload (->> js
-                          ;; only reload things we actually require'd somewhere
-                          (filter (fn [{:keys [provides]}]
-                                    (some #(js/goog.isProvided_ (str %)) provides)))
-                          (into []))]
-
+  (let [js-to-reload (into [] js)]
     (when (seq js-to-reload)
       (when before-load
         (let [fn (js/goog.getObjectByName before-load)]
@@ -75,4 +70,3 @@
 
 ;; shadow.cljs.api/build-dev will append a
 ;; (setup my-config) here
-


### PR DESCRIPTION
Fixes #16.

As far as I can tell, with the new REPLs code reloading is never going to work with this guard.

Additionally, my project has a number of multimethods in files that aren't explicitly required. (these are CLJX files that call a macro that defines one multimethod in clojure, one in clojurescript.) I'd like those files to reload when changed as well.

Not sure if there's a better way to implement this guard, but I sort of think it should be optional. Maybe allow the user to supply a custom function?
